### PR TITLE
tpath_preclear fixture works if the --no-preclear option isn't defined

### DIFF
--- a/src/wield/pytest/fixtures.py
+++ b/src/wield/pytest/fixtures.py
@@ -32,7 +32,10 @@ def tpath_preclear(request):
     before running each test. This cleans up the test data.
     """
     tpath_root, tpath_local = utilities.tpath_root_make(request)
-    no_preclear = request.config.getvalue("--no-preclear")
+    try:
+        no_preclear = request.config.getvalue("--no-preclear")
+    except ValueError:
+        no_preclear = False
     if not no_preclear:
         rmtree(tpath_root, ignore_errors=True)
     return


### PR DESCRIPTION
The `tpath_preclear` fixture clears the test path as long as the `--no-preclear` option isn't True, but there will be an error if this option hasn't been defined. This makes it so that the test path is still cleared without error if the `--no-preclear` option isn't defined.